### PR TITLE
fix(aks): sym link to version so providers get declared

### DIFF
--- a/aks/versions.tf
+++ b/aks/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
fixes:

```
➜  terra git:(test-modules) ✗ terraform init         
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Reference to undefined provider
│ 
│   on devops-stack-green.tf line 155, in module "ingress":
│  155:     argocd = argocd.green
│ 
│ The child module does not declare any provider requirement with the local name "argocd".
│ 
│ If you also control the child module, you can add a required_providers entry named "argocd" with the source address "oboukili/argocd"
│ to accept this provider configuration.

```

do we need this in every traefik variant ?