### PR TITLE
fix: separate DNS zone and cluster resource groups

### DIFF
--- a/aks/extra_variables.tf
+++ b/aks/extra_variables.tf
@@ -1,4 +1,9 @@
-variable "resource_group_name" {
-  description = "The Resource Group where the Managed Kubernetes Cluster should exist."
+variable "cluster_resource_group_name" {
+  description = "The cluster's resource group name."
+  type        = string
+}
+
+variable "dns_zone_resource_group_name" {
+  description = "The Azure DNS zone's resource group name."
   type        = string
 }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,10 +1,10 @@
 data "azurerm_dns_zone" "this" {
   name                = var.base_domain
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.dns_zone_resource_group_name
 }
 
-data "azurerm_resource_group" "this" {
-  name = var.resource_group_name
+data "azurerm_resource_group" "cluster_resource_group" {
+  name = var.cluster_resource_group_name
 }
 
 resource "azurerm_dns_cname_record" "wildcard" {
@@ -12,7 +12,7 @@ resource "azurerm_dns_cname_record" "wildcard" {
   zone_name           = data.azurerm_dns_zone.this.name
   resource_group_name = data.azurerm_dns_zone.this.resource_group_name
   ttl                 = 300
-  record              = "${local.azure_dns_label_name}.${data.azurerm_resource_group.this.location}.cloudapp.azure.com."
+  record              = "${local.azure_dns_label_name}.${data.azurerm_resource_group.cluster_resource_group.location}.cloudapp.azure.com."
 }
 
 module "traefik" {


### PR DESCRIPTION
When the DNS zone and the managed k8s cluster are in different locations, the alias of the wildcard DNS record created by the module and the DNS record pointing at the public IP address of the load balancer are different.