### PR TITLE
feat(wait): add dependency to var app_autosync

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "argocd_application" "this" {
     namespace = var.argocd_namespace
   }
 
-  wait = true
+  wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true
 
   spec {
     project = argocd_project.this.metadata.0.name

--- a/variables.tf
+++ b/variables.tf
@@ -43,8 +43,8 @@ variable "app_autosync" {
     allow_empty = optional(bool)
     prune       = optional(bool)
     self_heal   = optional(bool)
-  })  
-  default = { 
+  })
+  default = {
     allow_empty = false
     prune       = true
     self_heal   = true


### PR DESCRIPTION
if argocd sync is disabled, there is no reason to wait for resources to be deployed

this has been tested on scaleway