### PR TITLE
feat(sks): add configuration to make Traefik work with new SKS module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,9 +13,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>>
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 === Resources
 
@@ -141,8 +141,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_null]] <<provider_null,null>> |n/a
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -11,11 +11,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>>
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -140,9 +140,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -13,13 +13,31 @@ The following Modules are called:
 
 ==== [[module_traefik]] <<module_traefik,traefik>>
 
-Source: ../nodeport/
+Source: ../
 
 Version:
 
 === Required Inputs
 
 The following input variables are required:
+
+==== [[input_nlb_id]] <<input_nlb_id,nlb_id>>
+
+Description: ID of the Exoscale NLB to use for the SKS cluster.
+
+Type: `string`
+
+==== [[input_router_nodepool_id]] <<input_router_nodepool_id,router_nodepool_id>>
+
+Description: ID of the node pool specifically created for Traefik.
+
+Type: `string`
+
+==== [[input_router_instance_pool_id]] <<input_router_instance_pool_id,router_instance_pool_id>>
+
+Description: Instance pool ID of the node pool specifically created for Traefik.
+
+Type: `string`
 
 ==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
 
@@ -113,7 +131,7 @@ The following outputs are exported:
 
 ==== [[output_id]] <<output_id,id>>
 
-Description: n/a
+Description: ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -130,7 +148,7 @@ Description: n/a
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_traefik]] <<module_traefik,traefik>> |../nodeport/ |
+|[[module_traefik]] <<module_traefik,traefik>> |../ |
 |===
 
 = Inputs
@@ -138,6 +156,24 @@ Description: n/a
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_nlb_id]] <<input_nlb_id,nlb_id>>
+|ID of the Exoscale NLB to use for the SKS cluster.
+|`string`
+|n/a
+|yes
+
+|[[input_router_nodepool_id]] <<input_router_nodepool_id,router_nodepool_id>>
+|ID of the node pool specifically created for Traefik.
+|`string`
+|n/a
+|yes
+
+|[[input_router_instance_pool_id]] <<input_router_instance_pool_id,router_instance_pool_id>>
+|Instance pool ID of the node pool specifically created for Traefik.
+|`string`
+|n/a
+|yes
+
 |[[input_cluster_name]] <<input_cluster_name,cluster_name>>
 |Name given to the cluster. Value used for the ingress' URL of the application.
 |`string`
@@ -219,6 +255,6 @@ object({
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
-|[[output_id]] <<output_id,id>> |n/a
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
 |===
 // END_TF_TABLES

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -1,0 +1,14 @@
+variable "nlb_id" {
+  description = "ID of the Exoscale NLB to use for the SKS cluster."
+  type        = string
+}
+
+variable "router_nodepool_id" {
+  description = "ID of the node pool specifically created for Traefik."
+  type        = string
+}
+
+variable "router_instance_pool_id" {
+  description = "Instance pool ID of the node pool specifically created for Traefik."
+  type        = string
+}

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,3 +1,22 @@
 locals {
-  helm_values = []
+  helm_values = [{
+    traefik = {
+      service = {
+        annotations = {
+          "service.beta.kubernetes.io/exoscale-loadbalancer-id"                      = var.nlb_id
+          "service.beta.kubernetes.io/exoscale-loadbalancer-external"                = "true"
+          "service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id" = var.router_instance_pool_id
+        }
+      }
+      nodeSelector = {
+        "node.exoscale.net/nodepool-id" = var.router_nodepool_id
+      }
+      tolerations = [{
+        key      = "nodepool"
+        operator = "Equal"
+        value    = "router"
+        effect   = "NoSchedule"
+      }]
+    }
+  }]
 }

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,5 +1,5 @@
 module "traefik" {
-  source = "../nodeport/"
+  source = "../"
 
   cluster_name     = var.cluster_name
   base_domain      = var.base_domain

--- a/sks/outputs.tf
+++ b/sks/outputs.tf
@@ -1,3 +1,4 @@
 output "id" {
-  value = module.traefik.id
+  description = "ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place."
+  value       = module.traefik.id
 }


### PR DESCRIPTION
## Description of the changes

This PR works in conjunction with the PR on the SKS module -> https://github.com/camptocamp/devops-stack-module-cluster-sks/pull/2

It takes the IDs from the SKS module in order to deploy Traefik on the node pool specifically created for it. It also configures Traefik to deploy a service of type _LoadBalancer_ instead of _NodePort_, which then provisions the NLB services using the [Exoscale Cloud Controller Manager](https://github.com/exoscale/exoscale-cloud-controller-manager/blob/master/docs/service-loadbalancer.md).

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)