### PR TITLE
fix: enable_service_monitor variable propagation from flavors to base module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,11 +11,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>>
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>>
 
 === Resources
 
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -191,7 +191,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -223,7 +223,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -23,9 +23,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -49,7 +49,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -5,9 +5,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -199,7 +199,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -5,9 +5,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -49,7 +49,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/nodeport/main.tf
+++ b/nodeport/main.tf
@@ -5,9 +5,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -49,7 +49,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -5,9 +5,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -67,7 +67,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v1.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -203,7 +203,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v1.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -5,9 +5,10 @@ module "traefik" {
   base_domain      = var.base_domain
   argocd_namespace = var.argocd_namespace
 
-  target_revision = var.target_revision
-  namespace       = var.namespace
-  app_autosync    = var.app_autosync
+  target_revision        = var.target_revision
+  namespace              = var.namespace
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
 


### PR DESCRIPTION

## Breaking change

No

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)