### PR TITLE
fix(KinD): avoid deferring data source reading when Helm values change

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,9 +15,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 === Resources
 
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -194,7 +194,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -226,7 +226,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -202,7 +202,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -17,11 +17,7 @@ module "traefik" {
 
 data "kubernetes_service" "traefik" {
   metadata {
-    name      = local.helm_values.0.traefik.fullnameOverride
+    name      = replace(format("%s%s", local.helm_values.0.traefik.fullnameOverride, module.traefik.id), module.traefik.id ,"")
     namespace = var.namespace
   }
-
-  depends_on = [
-    module.traefik
-  ]
 }

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.1"`
+Default: `"v1.2.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -206,7 +206,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.1"`
+|`"v1.2.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes

`depends_on` meta-argument defers data source reading when Traefik Helm values change which prevents Keycloak provider from contacting the server to refresh the state of Keycloak resources.
Keycloak provider URL argument includes the data source output.
To summarize, we replace the hard dependency with a soft one.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)