### PR TITLE
feat!: add support to oboukili/argocd v5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -13,11 +13,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -141,7 +141,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -152,7 +152,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
@@ -194,7 +194,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -157,7 +157,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -226,7 +226,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -131,7 +131,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -147,7 +147,7 @@ Description: External IP address of Traefik LB service.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -202,7 +202,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -61,14 +61,19 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
-          duration     = ""
-          max_duration = ""
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "0"
+        limit = "5"
       }
 
       sync_options = [

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -131,7 +131,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -131,7 +131,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.2"`
+Default: `"v1.2.3"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -149,7 +149,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -206,7 +206,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.2"`
+|`"v1.2.3"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

Adapt the module to be compatible with ArgoCD versions >= 5.x (in counterpart, it now incompatible with previous versions of the provider). 
This change to the provider is needed to work with ArgoCD 2.7.x

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): _the module is no longer compatible with argocd provider versions < 5.x_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [ ] Scaleway
- [x] SKS (Exoscale)