### PR TITLE
fix/ci: fix autosync deactivation and add chart auto-updater workflow

### DIFF
--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,46 @@
+---
+name: "chart-update"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-update-schedule:
+    if: ${{ github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        update-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ matrix.update-strategy }}
+  
+  chart-update-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ inputs.update-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,5 @@
+:traefik-chart-version: 20.8.0
+
 // BEGIN_TF_DOCS
 === Requirements
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,11 +15,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -196,7 +196,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -226,7 +226,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/charts/traefik/Chart.yaml
+++ b/charts/traefik/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   This chart installs Traefik and configures it as the default Kubernetes cluster Ingress Controller.
 dependencies:
   - name: "traefik"
-    version: "^20"
+    version: "20.8.0"
     repository: "https://helm.traefik.io/traefik"

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -202,7 +202,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -61,10 +61,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -51,7 +51,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -170,7 +170,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.3"`
+Default: `"v2.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -206,7 +206,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.3"`
+|`"v2.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #52. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- adds the workflow that enables the auto-upgrade of the Helm charts.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)
- [x] KinD