### PR TITLE
feat/fix: enable HTTPS redirection, change CRD group and fix dependency_ids on Scaleway

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,6 +153,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -295,6 +303,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -167,6 +167,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -325,6 +333,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -19,16 +19,17 @@ resource "azurerm_dns_cname_record" "wildcard" {
 module "traefik" {
   source = "../"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/charts/traefik/templates/redirection-middleware.yaml
+++ b/charts/traefik/templates/redirection-middleware.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $value := index $.Values "traefik" "middlewares" "redirections" }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ $key }}

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -141,6 +141,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -269,6 +277,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,16 +1,17 @@
 module "traefik" {
   source = "../nodeport/"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -153,6 +153,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -301,6 +309,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -1,16 +1,17 @@
 module "traefik" {
   source = "../"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/locals.tf
+++ b/locals.tf
@@ -28,6 +28,13 @@ locals {
           minVersion = "VersionTLS12"
         }
       }
+      ports = var.enable_https_redirection ? {
+        web = {
+          redirectTo = {
+            port = "websecure"
+          }
+        }
+      } : null
       ressources = {
         limits = {
           cpu    = "250m"

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -141,6 +141,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -269,6 +277,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/nodeport/main.tf
+++ b/nodeport/main.tf
@@ -1,16 +1,17 @@
 module "traefik" {
   source = "../"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -141,6 +141,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -269,6 +277,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -14,4 +14,6 @@ module "traefik" {
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
+
+  dependency_ids = var.dependency_ids
 }

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -1,16 +1,17 @@
 module "traefik" {
   source = "../nodeport/"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -159,6 +159,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+
+Description: Enable HTTP to HTTPS redirection on all ingresses.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -305,6 +313,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
+|Enable HTTP to HTTPS redirection on all ingresses.
+|`bool`
+|`true`
 |no
 
 |===

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,16 +1,17 @@
 module "traefik" {
   source = "../"
 
-  cluster_name           = var.cluster_name
-  base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
-  argocd_project         = var.argocd_project
-  argocd_labels          = var.argocd_labels
-  destination_cluster    = var.destination_cluster
-  target_revision        = var.target_revision
-  namespace              = var.namespace
-  enable_service_monitor = var.enable_service_monitor
-  app_autosync           = var.app_autosync
+  cluster_name             = var.cluster_name
+  base_domain              = var.base_domain
+  argocd_namespace         = var.argocd_namespace
+  argocd_project           = var.argocd_project
+  argocd_labels            = var.argocd_labels
+  destination_cluster      = var.destination_cluster
+  target_revision          = var.target_revision
+  namespace                = var.namespace
+  enable_service_monitor   = var.enable_service_monitor
+  app_autosync             = var.app_autosync
+  enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,9 @@ variable "dependency_ids" {
 #######################
 ## Module variables
 #######################
+
+variable "enable_https_redirection" {
+  description = "Enable HTTP to HTTPS redirection on all ingresses."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Description of the changes

This PR:
- Enables the HTTP to HTTPS redirection by default and adds a variable to disable it if desired.
- Changes the CRD group on the redirection middleware used to redirect non colorized domains to colorized domains.
- Fixes an issue in the Scaleway variant where the `dependency_ids` variable was not propagated to the main module.

:warning: **Do a _Rebase and merge_**.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)