### PR TITLE
feat(aks)!: remove the DNS resource from this module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,7 +87,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -96,14 +96,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -152,6 +144,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -246,19 +246,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -303,6 +297,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -9,12 +9,6 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
-=== Providers
-
-The following providers are used by this module:
-
-- [[provider_azurerm]] <<provider_azurerm,azurerm>>
-
 === Modules
 
 The following Modules are called:
@@ -25,29 +19,9 @@ Source: ../
 
 Version:
 
-=== Resources
-
-The following resources are used by this module:
-
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record[azurerm_dns_cname_record.wildcard] (resource)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone[azurerm_dns_zone.this] (data source)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.nodes_resource_group] (data source)
-
 === Required Inputs
 
 The following input variables are required:
-
-==== [[input_node_resource_group_name]] <<input_node_resource_group_name,node_resource_group_name>>
-
-Description: The aks managed cluster resource group name.
-
-Type: `string`
-
-==== [[input_dns_zone_resource_group_name]] <<input_dns_zone_resource_group_name,dns_zone_resource_group_name>>
-
-Description: The Azure DNS zone's resource group name.
-
-Type: `string`
 
 ==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
 
@@ -101,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -110,14 +84,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -167,6 +133,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
+
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
 Description: Enable HTTP to HTTPS redirection on all ingresses.
@@ -194,14 +168,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
-= Providers
-
-[cols="a,a",options="header,autowidth"]
-|===
-|Name |Version
-|[[provider_azurerm]] <<provider_azurerm,azurerm>> |n/a
-|===
-
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
@@ -210,33 +176,11 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[module_traefik]] <<module_traefik,traefik>> |../ |
 |===
 
-= Resources
-
-[cols="a,a",options="header,autowidth"]
-|===
-|Name |Type
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record[azurerm_dns_cname_record.wildcard] |resource
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone[azurerm_dns_zone.this] |data source
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.nodes_resource_group] |data source
-|===
-
 = Inputs
 
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_node_resource_group_name]] <<input_node_resource_group_name,node_resource_group_name>>
-|The aks managed cluster resource group name.
-|`string`
-|n/a
-|yes
-
-|[[input_dns_zone_resource_group_name]] <<input_dns_zone_resource_group_name,dns_zone_resource_group_name>>
-|The Azure DNS zone's resource group name.
-|`string`
-|n/a
-|yes
-
 |[[input_cluster_name]] <<input_cluster_name,cluster_name>>
 |Name given to the cluster. Value used for the ingress' URL of the application.
 |`string`
@@ -276,19 +220,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -333,6 +271,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/aks/extra_variables.tf
+++ b/aks/extra_variables.tf
@@ -1,9 +1,1 @@
-variable "node_resource_group_name" {
-  description = "The aks managed cluster resource group name."
-  type        = string
-}
 
-variable "dns_zone_resource_group_name" {
-  description = "The Azure DNS zone's resource group name."
-  type        = string
-}

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,21 +1,3 @@
-data "azurerm_dns_zone" "this" {
-  name                = var.base_domain
-  resource_group_name = var.dns_zone_resource_group_name
-}
-
-data "azurerm_resource_group" "nodes_resource_group" {
-  name = var.node_resource_group_name
-}
-
-# TODO should we move this out of here?
-resource "azurerm_dns_cname_record" "wildcard" {
-  name                = "*.apps.${var.cluster_name}"
-  zone_name           = data.azurerm_dns_zone.this.name
-  resource_group_name = data.azurerm_dns_zone.this.resource_group_name
-  ttl                 = 300
-  record              = "${local.azure_dns_label_name}.${data.azurerm_resource_group.nodes_resource_group.location}.cloudapp.azure.com."
-}
-
 module "traefik" {
   source = "../"
 

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -84,14 +84,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -140,6 +132,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -220,19 +220,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -277,6 +271,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -87,7 +87,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -96,14 +96,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -152,6 +144,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -252,19 +252,13 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -309,6 +303,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
             enabled = true
           }
           serviceMonitor = var.enable_service_monitor ? {
-            # dummy attribute to make serviceMonitor evaluate to true in a condition in the helm chart
+            # Dummy attribute to make serviceMonitor evaluate to true in a condition in the Helm chart
             foo = "bar"
           } : {}
         }

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -84,14 +84,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -140,6 +132,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -220,19 +220,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -277,6 +271,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -84,14 +84,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -140,6 +132,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -220,19 +220,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -277,6 +271,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -93,7 +93,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -102,14 +102,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"traefik"`
-
-==== [[input_replicas]] <<input_replicas,replicas>>
-
-Description: Number of Traefik pods to be deployed.
-
-Type: `string`
-
-Default: `"2"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -158,6 +150,14 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
+
+==== [[input_replicas]] <<input_replicas,replicas>>
+
+Description: Number of Traefik pods to be deployed.
+
+Type: `number`
+
+Default: `2`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -256,19 +256,13 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"traefik"`
-|no
-
-|[[input_replicas]] <<input_replicas,replicas>>
-|Number of Traefik pods to be deployed.
-|`string`
-|`"2"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -313,6 +307,12 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_replicas]] <<input_replicas,replicas>>
+|Number of Traefik pods to be deployed.
+|`number`
+|`2`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/variables.tf
+++ b/variables.tf
@@ -47,12 +47,6 @@ variable "namespace" {
   default     = "traefik"
 }
 
-variable "replicas" {
-  description = "Number of Traefik pods to be deployed."
-  type        = string
-  default     = "2"
-}
-
 variable "enable_service_monitor" {
   description = "Enable Prometheus ServiceMonitor in the Helm chart."
   type        = bool
@@ -88,6 +82,12 @@ variable "dependency_ids" {
 #######################
 ## Module variables
 #######################
+
+variable "replicas" {
+  description = "Number of Traefik pods to be deployed."
+  type        = number
+  default     = 2
+}
 
 variable "enable_https_redirection" {
   description = "Enable HTTP to HTTPS redirection on all ingresses."


### PR DESCRIPTION
## Description of the changes

This PR does the following:

- Remove the creation of the DNS records for the cluster from this module and instead include it on the AKS cluster module -> https://github.com/camptocamp/devops-stack-module-cluster-aks/pull/1
- A small refactoring on the `replicas` variable;
- Rewording of a comment on the code.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): **we've removed the creation of the DNS record from this module and this will require AKS users to deploy the cluster using the new AKS module, because of that I'll mark this PR as a breaking change.**

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)