### PR TITLE
fix!: remove the namespace variable and hardcode the Helm release name 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,11 +15,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -44,12 +44,6 @@ Type: `string`
 ==== [[input_base_domain]] <<input_base_domain,base_domain>>
 
 Description: Base domain of the cluster. Value used for the ingress' URL of the application.
-
-Type: `string`
-
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
@@ -88,14 +82,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -219,12 +205,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -247,12 +227,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -35,12 +35,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -76,14 +70,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -193,12 +179,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -221,12 +201,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -35,12 +35,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -76,14 +70,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -193,12 +179,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -221,12 +201,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -47,12 +47,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -88,14 +82,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -225,12 +211,6 @@ Description: External IP address of Traefik LB service.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -253,12 +233,6 @@ Description: External IP address of Traefik LB service.
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection
@@ -21,6 +20,6 @@ module "traefik" {
 data "kubernetes_service" "traefik" {
   metadata {
     name      = replace(format("%s%s", local.helm_values.0.traefik.fullnameOverride, module.traefik.id), module.traefik.id, "")
-    namespace = var.namespace
+    namespace = "traefik"
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -35,7 +35,7 @@ locals {
           }
         }
       } : null
-      ressources = {
+      ressources = { # TODO: use var.resources instead and fix the typo in "reSSources"
         limits = {
           cpu    = "250m"
           memory = "512Mi"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,8 @@ resource "argocd_application" "this" {
       path            = "charts/traefik"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "traefik"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "traefik-${var.destination_cluster}" : "traefik"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -40,7 +37,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "traefik-${var.destination_cluster}" : "traefik"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "traefik"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "traefik"
     }
 
     orphaned_resources {
@@ -64,7 +64,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "traefik"
     }
 
     sync_policy {

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -35,12 +35,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -76,14 +70,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -193,12 +179,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -221,12 +201,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/nodeport/main.tf
+++ b/nodeport/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/nodeport/main.tf
+++ b/nodeport/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -35,12 +35,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -76,14 +70,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -193,12 +179,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -221,12 +201,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -53,12 +53,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -94,14 +88,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v4.1.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"traefik"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -229,12 +215,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -257,12 +237,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v4.1.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"traefik"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,7 +3,6 @@ module "traefik" {
 
   cluster_name             = var.cluster_name
   base_domain              = var.base_domain
-  argocd_namespace         = var.argocd_namespace
   argocd_project           = var.argocd_project
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -8,7 +8,6 @@ module "traefik" {
   argocd_labels            = var.argocd_labels
   destination_cluster      = var.destination_cluster
   target_revision          = var.target_revision
-  namespace                = var.namespace
   enable_service_monitor   = var.enable_service_monitor
   app_autosync             = var.app_autosync
   enable_https_redirection = var.enable_https_redirection

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,6 @@ variable "base_domain" {
   type        = string
 }
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -41,12 +41,6 @@ variable "target_revision" {
   default     = "v4.1.0" # x-release-please-version
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "traefik"
-}
-
 variable "enable_service_monitor" {
   description = "Enable Prometheus ServiceMonitor in the Helm chart."
   type        = bool


### PR DESCRIPTION
## Description of the changes

Three commits compose this PR:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)