### PR TITLE
fix: remove leftover unused variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -131,14 +131,6 @@ Type: `bool`
 
 Default: `true`
 
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
-
-Type: `bool`
-
-Default: `true`
-
 === Outputs
 
 The following outputs are exported:
@@ -163,9 +155,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -206,7 +198,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -261,12 +253,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -130,14 +130,6 @@ Default: `2`
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
 Description: Enable HTTP to HTTPS redirection on all ingresses.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
 
 Type: `bool`
 
@@ -208,7 +200,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -263,12 +255,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -119,14 +119,6 @@ Type: `bool`
 
 Default: `true`
 
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
-
-Type: `bool`
-
-Default: `true`
-
 === Outputs
 
 The following outputs are exported:
@@ -180,7 +172,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -235,12 +227,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -126,14 +126,6 @@ Default: `2`
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
 Description: Enable HTTP to HTTPS redirection on all ingresses.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
 
 Type: `bool`
 
@@ -212,7 +204,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -267,12 +259,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -119,14 +119,6 @@ Type: `bool`
 
 Default: `true`
 
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
-
-Type: `bool`
-
-Default: `true`
-
 === Outputs
 
 The following outputs are exported:
@@ -180,7 +172,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -235,12 +227,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -119,14 +119,6 @@ Type: `bool`
 
 Default: `true`
 
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
-
-Type: `bool`
-
-Default: `true`
-
 === Outputs
 
 The following outputs are exported:
@@ -180,7 +172,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -235,12 +227,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -136,14 +136,6 @@ Default: `2`
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
 Description: Enable HTTP to HTTPS redirection on all ingresses.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-
-Description: Enable the middleware to add the cluster name in the URL when it is not present.
 
 Type: `bool`
 
@@ -220,7 +212,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -275,12 +267,6 @@ object({
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 |Enable HTTP to HTTPS redirection on all ingresses.
-|`bool`
-|`true`
-|no
-
-|[[input_enable_cluster_name_redirection_middleware]] <<input_enable_cluster_name_redirection_middleware,enable_cluster_name_redirection_middleware>>
-|Enable the middleware to add the cluster name in the URL when it is not present.
 |`bool`
 |`true`
 |no

--- a/variables.tf
+++ b/variables.tf
@@ -73,9 +73,3 @@ variable "enable_https_redirection" {
   type        = bool
   default     = true
 }
-
-variable "enable_cluster_name_redirection_middleware" {
-  description = "Enable the middleware to add the cluster name in the URL when it is not present."
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
## Description of the changes

This PR removes a variable I added as a first proposal to disable the middleware. In the end, this is not needed because we've removed the middleware altogether. However, I forgot to remove the variable on my last PR.

## Breaking change

- [x] No - the variable was never used, so this is not a breaking change.