### PR TITLE
feat: add variable to set resources with default values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -122,6 +122,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -198,7 +221,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -249,6 +272,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -126,6 +126,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -200,7 +223,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -251,6 +274,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -110,6 +110,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -172,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -223,6 +246,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../nodeport/"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -122,6 +122,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -204,7 +227,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -255,6 +278,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/locals.tf
+++ b/locals.tf
@@ -35,15 +35,9 @@ locals {
           }
         }
       } : null
-      ressources = { # TODO: use var.resources instead and fix the typo in "reSSources"
-        limits = {
-          cpu    = "250m"
-          memory = "512Mi"
-        }
-        requests = {
-          cpu    = "125m"
-          memory = "256Mi"
-        }
+      resources = {
+        requests = { for k, v in var.resources.requests : k => v if v != null }
+        limits   = { for k, v in var.resources.limits : k => v if v != null }
       }
     }
   }]

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -110,6 +110,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -172,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -223,6 +246,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/nodeport/main.tf
+++ b/nodeport/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -110,6 +110,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -172,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -223,6 +246,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../nodeport/"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.1.1"`
+Default: `"v6.2.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -132,6 +132,29 @@ Description: Number of Traefik pods to be deployed.
 Type: `number`
 
 Default: `2`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+Default: `{}`
 
 ==== [[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>
 
@@ -212,7 +235,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.1.1"`
+|`"v6.2.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -263,6 +286,30 @@ object({
 |Number of Traefik pods to be deployed.
 |`number`
 |`2`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+----
+
+|`{}`
 |no
 
 |[[input_enable_https_redirection]] <<input_enable_https_redirection,enable_https_redirection>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,12 +1,15 @@
 module "traefik" {
   source = "../"
 
-  argocd_project           = var.argocd_project
-  argocd_labels            = var.argocd_labels
-  destination_cluster      = var.destination_cluster
-  target_revision          = var.target_revision
-  enable_service_monitor   = var.enable_service_monitor
-  app_autosync             = var.app_autosync
+  argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
+  destination_cluster    = var.destination_cluster
+  target_revision        = var.target_revision
+  enable_service_monitor = var.enable_service_monitor
+  app_autosync           = var.app_autosync
+
+  replicas                 = var.replicas
+  resources                = var.resources
   enable_https_redirection = var.enable_https_redirection
 
   helm_values = concat(local.helm_values, var.helm_values)

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,25 @@ variable "replicas" {
   default     = 2
 }
 
+variable "resources" {
+  description = <<-EOT
+    Resource limits and requests for Traefik's pods. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+    IMPORTANT: These are not production values. You should always adjust them to your needs.
+  EOT
+  type = object({
+    requests = optional(object({
+      cpu    = optional(string, "150m")
+      memory = optional(string, "128Mi")
+    }), {})
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string, "256Mi")
+    }), {})
+  })
+  default = {}
+}
+
 variable "enable_https_redirection" {
   description = "Enable HTTP to HTTPS redirection on all ingresses."
   type        = bool


### PR DESCRIPTION
## Description of the changes

This PR adds a variable to set resources' limits and requests on the module components.

Having default values is good practice to prevent that our components could eventually starve other workloads on the cluster. However, these should probably be adapted in production clusters and are only a safeguard in case someone forgets to set them.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)