### PR TITLE
chore(scaleway-variant): add lb annotation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,11 +15,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -178,9 +178,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources
@@ -221,7 +221,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -223,7 +223,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -195,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -227,7 +227,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -195,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -19,6 +19,16 @@ Source: ../nodeport/
 
 Version:
 
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_lb_id]] <<input_lb_id,lb_id>>
+
+Description: ID of the main load balancer
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -53,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -174,6 +184,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_lb_id]] <<input_lb_id,lb_id>>
+|ID of the main load balancer
+|`string`
+|n/a
+|yes
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -195,7 +211,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/extra-variables.tf
+++ b/scaleway/extra-variables.tf
@@ -1,0 +1,4 @@
+variable "lb_id" {
+  type        = string
+  description = "ID of the main load balancer"
+}

--- a/scaleway/local.tf
+++ b/scaleway/local.tf
@@ -1,3 +1,13 @@
 locals {
-  helm_values = []
+  helm_values = [{
+    traefik = {
+      service = {
+        type = "LoadBalancer"
+        annotations = {
+          "service.beta.kubernetes.io/scw-loadbalancer-id" = var.lb_id
+        }
+      }
+    }
+  }]
 }
+

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.2.0"`
+Default: `"v6.3.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -235,7 +235,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.2.0"`
+|`"v6.3.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>


### PR DESCRIPTION
Use scaleway annotation for load balancer. 

The change only impacts scaleway part.

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_


## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [X] Scaleway
- [ ] SKS (Exoscale)