### PR TITLE
feat: add a label to traefik pods

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -221,7 +221,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -69,7 +69,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -223,7 +223,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -195,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -65,7 +65,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -227,7 +227,7 @@ Description: External IP address of Traefik LB service.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,9 @@ locals {
     traefik = {
       deployment = {
         replicas = var.replicas
+        podLabels = {
+          app = "traefik"
+        }
       }
       metrics = {
         prometheus = {

--- a/nodeport/README.adoc
+++ b/nodeport/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -195,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -53,7 +53,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -195,7 +195,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.1.0"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -235,7 +235,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.1.0"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>


### PR DESCRIPTION
## Description of the changes

This pull request adds a custom pod label to Traefik. This is helpful because it gives us control over the labels we use, instead of relying on the default ones that might change in future updates. This ensures our setup remains consistent and reliable.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD